### PR TITLE
Replaces the 'dd' prefix with the DynamicData property 'PropertyPrefix'.

### DIFF
--- a/DynamicDataCmd.py
+++ b/DynamicDataCmd.py
@@ -209,7 +209,7 @@ class DynamicDataCreateObjectCommandClass(object):
 
     def Activated(self):
         doc = FreeCAD.ActiveDocument
-        doc.openTransaction("CreateObject")
+        doc.openTransaction("dd CreateObject")
         a = doc.addObject("App::FeaturePython","dd")
         a.addProperty("App::PropertyStringList","DynamicData").DynamicData=self.getHelp()
         setattr(a.ViewObject,'DisplayMode',['0']) #avoid enumeration -1 warning
@@ -841,7 +841,7 @@ Enumeration to edit.  Create one first, and then try again.\n")
         dlg.props = self.props
         dlg.exec_()
         if dlg.ok:
-            doc.openTransaction("Edit Enumeration")
+            doc.openTransaction("dd Edit Enumeration")
             self.setEnumerations(dlg.enumerations)
             doc.commitTransaction()
         doc.recompute()
@@ -1436,7 +1436,7 @@ Select source group to pick properties from, or all groups to pick from all.\n',
                     newName = item2
                 if not ok:
                     return
-                doc.openTransaction("Move to new group")
+                doc.openTransaction("dd Move to new group")
                 for prop in props:
                     try:
                         obj.setGroupOfProperty(prop,newName)
@@ -1832,7 +1832,7 @@ The new properties will remain after the undo, but they will no longer reference
 You should save your document before proceeding.\n',items,0,False,windowFlags)
         if not ok or item==items[-1]:
             return
-        FreeCAD.ActiveDocument.openTransaction("dd Import Aliases") #setup undo
+        doc.openTransaction("dd Import Aliases") #setup undo
         aliases=[]
         for sheet in sheets:
             for line in sheet.cells.Content.splitlines():

--- a/DynamicDataCmd.py
+++ b/DynamicDataCmd.py
@@ -672,12 +672,13 @@ you can use Undo to revert all your changes to the selected object.
             self.configuration["variableCount"] = len(vars)
 
         def makeDefaultConfiguration(self):
+            propertyPrefix = self.dd.getPropertyByName('PropertyPrefix')
             self.configuration["name"] = "Configuration"
             self.configuration["enumCount"] = 5
             self.configuration["variableCount"] = 3
             self.configuration["enums"] = ["Select size","Extra Small","Small","Medium",\
                                         "Large","Extra Large"]
-            self.configuration["variables"] = ["Length", "Height", "Radius"]
+            self.configuration["variables"] = [f'{propertyPrefix}Length', f'{propertyPrefix}Height', f'{propertyPrefix}Radius']
             self.configuration["lineEdits"] = {}
 
         def fillUpLineEdits(self):

--- a/DynamicDataCmd.py
+++ b/DynamicDataCmd.py
@@ -212,6 +212,17 @@ class DynamicDataCreateObjectCommandClass(object):
         doc.openTransaction("dd CreateObject")
         a = doc.addObject("App::FeaturePython","dd")
         a.addProperty("App::PropertyStringList","DynamicData").DynamicData=self.getHelp()
+        version = tuple(int(i) for i in FreeCAD.Version()[:2])
+        # `FreeCAD.Version() returns e.g.
+        #   ['0', '21', '1',
+        #   '33694 (Git)', 'https://github.com/FreeCAD/FreeCAD',
+        #   '2023/08/31 02:32:05', '(HEAD detached at 0.21.1)',
+        #   'f6708547a9bb3f71a4aaade12109f511a72c207c']
+        if version < (0, 22):
+            propertyPrefix = 'dd'
+        else:
+            propertyPrefix = ''
+        a.addProperty('App::PropertyString', 'PropertyPrefix').PropertyPrefix = propertyPrefix
         setattr(a.ViewObject,'DisplayMode',['0']) #avoid enumeration -1 warning
         doc.commitTransaction()
         Gui.Selection.clearSelection()

--- a/DynamicDataCmd.py
+++ b/DynamicDataCmd.py
@@ -143,7 +143,7 @@ xyzTypes = [#x,y,z elements must be linked separately
 #######################################################################################
 # Keep Toolbar active even after leaving workbench
 
-class DynamicDataSettingsCommandClass(object):
+class DynamicDataSettingsCommandClass:
     """Settings, currently only whether to keep toolbar after leaving workbench"""
     global mostRecentTypes
 
@@ -198,7 +198,7 @@ class DynamicDataSettingsCommandClass(object):
 ####################################################################################
 # Create the dynamic data container object
 
-class DynamicDataCreateObjectCommandClass(object):
+class DynamicDataCreateObjectCommandClass:
     """Create Object command"""
 
     def GetResources(self):
@@ -254,7 +254,7 @@ class DynamicDataCreateObjectCommandClass(object):
 ####################################################################################
 # Create or edit an existing configuration
 
-class DynamicDataCreateConfigurationCommandClass(object):
+class DynamicDataCreateConfigurationCommandClass:
     """Create or edit a configuration command"""
     class DynamicDataConfigurationDlg(QtGui.QDialog):
         def __init__(self,dd):
@@ -738,7 +738,7 @@ you can use Undo to revert all your changes to the selected object.
 ####################################################################################
 # Edit an existing Enumeration property
 
-class DynamicDataEditEnumerationCommandClass(object):
+class DynamicDataEditEnumerationCommandClass:
     """Edit Enumeration command"""
 
     class DynamicDataEnumerationDlg(QtGui.QDialog):
@@ -1014,7 +1014,7 @@ class MultiTextInput(QtGui.QDialog):
 # Add a dynamic property to the object
 
 
-class DynamicDataAddPropertyCommandClass(object):
+class DynamicDataAddPropertyCommandClass:
     """Add Property Command"""
     global mostRecentTypes
     global mostRecentTypesLength

--- a/DynamicDataCmd.py
+++ b/DynamicDataCmd.py
@@ -1502,7 +1502,6 @@ class DynamicDataRenamePropertyCommandClass(_DynamicDataPropertyCommandClass):
                 'Accel'   : "Ctrl+Shift+D,N",
                 'ToolTip' : "Rename a dynamic property"}
 
-
     def getProperty(self,obj):
         props = self._getDynamicProperties(obj)
         if props:
@@ -1611,7 +1610,6 @@ class DynamicDataSetTooltipCommandClass(_DynamicDataPropertyCommandClass):
                 'MenuText': "Se&t Tooltip",
                 'Accel'   : "Ctrl+Shift+D,T",
                 'ToolTip' : "Set the tooltip of a dynamic property"}
-
 
     def getProperty(self,obj):
         props = self._getDynamicProperties(obj)
@@ -1749,12 +1747,9 @@ class DynamicDataImportAliasesCommandClass(_DynamicDataPropertyCommandClass):
     def GetResources(self):
         return {'Pixmap'  : os.path.join( iconPath , 'ImportAliases.svg'),
                 'MenuText': "&Import Aliases",
-
                 'ToolTip' : "Import aliases from selected spreadsheet(s) into selected DynamicData object"}
 
     def Activated(self):
-
-
         sheets=[]
         dd = None
         doc = FreeCAD.ActiveDocument
@@ -1910,7 +1905,6 @@ class DynamicDataImportNamedConstraintsCommandClass(_DynamicDataPropertyCommandC
     def GetResources(self):
         return {'Pixmap'  : os.path.join( iconPath , 'ImportNamedConstraints.svg'),
                 'MenuText': "&Import Named Constraints",
-
                 'ToolTip' : "Import named constraints from selected sketch(es) into selected DynamicData object"}
 
     def Activated(self):
@@ -2045,7 +2039,6 @@ class DynamicDataCopyPropertyCommandClass(_DynamicDataPropertyCommandClass):
         return {'Pixmap'  : os.path.join( iconPath , 'CopyProperty.svg'),
                 'MenuText': "C&opy Property",
                 'ToolTip' : "Copy/Set property values between selected objects"}
-
 
     def Activated(self):
         breakOnly = False #only break existing parametric link if True

--- a/DynamicDataCmd.py
+++ b/DynamicDataCmd.py
@@ -581,7 +581,7 @@ you can use Undo to revert all your changes to the selected object.
                     val = float(lineEdit.text())
                 except:
                     if lineEdit.text():
-                        FreeCAD.Console.PrintWarning(f"Couldn't convert to float: {lineEdit.text()} row,col = {row},{col}\n")
+                        FreeCAD.Console.PrintWarning(f"DynamicData: Couldn't convert to float: {lineEdit.text()} row,col = {row},{col}\n")
                     else:
                         #take value from first cell in row and use that for default
                         firstCell = self.getLineEditFromConfiguration(f"{row+1}_{1}")
@@ -600,7 +600,7 @@ you can use Undo to revert all your changes to the selected object.
                 try:
                     dd.removeProperty(name)
                 except:
-                    FreeCAD.Console.PrintWarning(f"Unable to remove property: {name}\n")
+                    FreeCAD.Console.PrintWarning(f'DynamicData: Unable to remove property: {name}\n')
             if not hasattr(dd,name):
                 dd.addProperty("App::PropertyEnumeration",name,name,"Configuration enumeration")
             setattr(dd,name,self.configuration["enums"])
@@ -608,22 +608,22 @@ you can use Undo to revert all your changes to the selected object.
                 if hasattr(dd,f"{var}List"):
                     try:
                         dd.removeProperty(f"{var}List")
-                        FreeCAD.Console.PrintMessage(f"Removed property {var}List\n")
+                        FreeCAD.Console.PrintMessage(f'DynamicData: Removed property {var}List\n')
                     except:
-                        FreeCAD.Console.PrintWarning(f"Unable to remove property: {var}List\n")
+                        FreeCAD.Console.PrintWarning(f'DynamicData: Unable to remove property: {var}List\n')
                 if not hasattr(dd,f"{var}List"):
                     dd.addProperty("App::PropertyFloatList",f"{var}List",f"{name}Lists",f"List property for {var}")
-                    FreeCAD.Console.PrintMessage(f"Added property {var}List\n")
+                    FreeCAD.Console.PrintMessage(f'DynamicData: Added property {var}List\n')
                 setattr(dd,f"{var}List", self.getRowValues(row))
                 if hasattr(dd,var):
                     try:
                         dd.removeProperty(var)
-                        FreeCAD.Console.PrintMessage(f"Removed property {var}\n")
+                        FreeCAD.Console.PrintMessage(f'DynamicData: Removed property {var}\n')
                     except:
-                        FreeCAD.Console.PrintWarning(f"Unable to remove property: {var}\n")
+                        FreeCAD.Console.PrintWarning(f'DynamicData: Unable to remove property: {var}\n')
                 if not hasattr(dd,var):
                     dd.addProperty("App::PropertyFloat",var,name,"Property to link to")
-                    FreeCAD.Console.PrintMessage(f"Added property {var}\n")
+                    FreeCAD.Console.PrintMessage(f'DynamicData: Added property {var}\n')
                 dd.setExpression(var,f"{dd.Label}.<<{dd.Label}>>.{var}List[<<{dd.Label}>>.{name}-1]")
 
         def getConfigurationFromObject(self):
@@ -833,8 +833,10 @@ class DynamicDataEditEnumerationCommandClass(object):
     def Activated(self):
         doc = FreeCAD.ActiveDocument
         if not self.props:
-            FreeCAD.Console.PrintError("DynamicData: Error, no property of type \
-Enumeration to edit.  Create one first, and then try again.\n")
+            FreeCAD.Console.PrintError(
+                'DynamicData: '
+                'Error, no property of type Enumeration to edit.  '
+                'Create one first, and then try again.\n')
             return
 
         dlg = self.DynamicDataEnumerationDlg(self.obj, self.props) #the dd object
@@ -1022,7 +1024,7 @@ class DynamicDataAddPropertyCommandClass(object):
         doc = FreeCAD.ActiveDocument
         obj = self.obj
         if not 'FeaturePython' in str(obj.TypeId):
-            FreeCAD.Console.PrintError('DynamicData Workbench: Cannot add property to non-FeaturePython objects.\n')
+            FreeCAD.Console.PrintError('DynamicData: Cannot add property to non-FeaturePython objects.\n')
             return
         doc.openTransaction("dd Add Property")
         #add the property
@@ -1131,10 +1133,10 @@ class DynamicDataAddPropertyCommandClass(object):
                         if len(split[ii])>0:
                             vals.append(self.eval_expr(split[ii]))
                     except Exception as ex:
-                        FreeCAD.Console.PrintError(f"dd: {ex}\n")
+                        FreeCAD.Console.PrintError(f"DynamicData: {ex}\n")
                         vals.append(split[ii])
         if hasattr(obj,'dd'+self.propertyName):
-            FreeCAD.Console.PrintError('DyamicData: Unable to add property: dd'+self.propertyName+' because it already exists.\n')
+            FreeCAD.Console.PrintError(f'DynamicData: Unable to add property: {propertyPrefix}{self.propertyName} because it already exists.\n')
             self.checkAddAnother(dlg)
             return
         p = obj.addProperty('App::Property'+item,'dd'+self.propertyName,str(self.groupName),self.tooltip)
@@ -1148,7 +1150,7 @@ class DynamicDataAddPropertyCommandClass(object):
                     self.checkAddAnother(dlg)
                     return
                 except:
-                    FreeCAD.Console.PrintWarning('DynamicData: Unable to set expreesion: '+str(val[1:])+'\n')
+                    FreeCAD.Console.PrintWarning(f'DynamicData: Unable to set expression: {val[1:]}\n')
                     doc.commitTransaction()
                     self.checkAddAnother(dlg)
                     return
@@ -1158,18 +1160,18 @@ class DynamicDataAddPropertyCommandClass(object):
                 #try:
                 #    atr = val
                 #except:
-                FreeCAD.Console.PrintWarning('DynamicData: Unable to set value: '+str(val)+'\n')
+                FreeCAD.Console.PrintWarning(f'DynamicData: Unable to set value: {val}\n')
             try:
                 if item == "Enumeration":
                     list2 = split[3:]
                     try:
                         setattr(p,'dd'+self.propertyName, list2)
                     except Exception:
-                        FreeCAD.Console.PrintWarning("DynamicData: Unable to set list enumeration: "+str(list)+"\n")
+                        FreeCAD.Console.PrintWarning(f'DynamicData: Unable to set list enumeration: {list}\n')
                 else:
                     setattr(p,'dd'+self.propertyName,atr)
             except:
-                FreeCAD.Console.PrintWarning('DynamicData: Unable to set attribute: '+str(val)+'\n')
+                FreeCAD.Console.PrintWarning(f'DynamicData: Unable to set attribute: {val}\n')
         elif hasVal and len(vals)>0:
             if listval:
                 try:
@@ -1180,14 +1182,14 @@ class DynamicDataAddPropertyCommandClass(object):
                     self.checkAddAnother(dlg)
                     return
                 except:
-                    FreeCAD.Console.PrintWarning('DynamicData: Unable to set expression: '+str(listval[1:])+'\n')
+                    FreeCAD.Console.PrintWarning(f'DynamicData: Unable to set expression: {listval[1:]}\n')
                     doc.commitTransaction()
                     self.checkAddAnother(dlg)
                     return
             try:
                 setattr(p,'dd'+self.propertyName,list(vals))
             except:
-                FreeCAD.Console.PrintWarning('DynamicData: Unable to set list attribute: '+str(vals)+'\n')
+                FreeCAD.Console.PrintWarning(f'DynamicData: Unable to set list attribute: {vals}\n')
         obj.touch()
         doc.recompute()
 
@@ -1285,7 +1287,7 @@ class DynamicDataAddPropertyCommandClass(object):
                 else:
                     return func(float(opstring))
             else:
-                App.Console.PrintError('ast evaluator: unsupported token: '+node.id+'\n')
+                App.Console.PrintError(f'DynamicData: AST evaluator: unsupported token: {node.id}\n')
         else:
             raise TypeError(node)
 
@@ -1411,10 +1413,10 @@ Only works with dynamic properties"}
         window = FreeCADGui.getMainWindow()
         items = self.getGroups(obj)
         if not items:
-            FreeCAD.Console.PrintError(f"DynamicData::Error -- no groups of {obj.Label} may be renamed\n")
+            FreeCAD.Console.PrintError(f'DynamicData: Error -- no groups of {obj.Label} may be renamed\n')
             return
         if len(items)==0:
-            FreeCAD.Console.PrintMessage("DyanmicData: no properties.\n")
+            FreeCAD.Console.PrintMessage('DynamicData: No properties.\n')
             return
         items.insert(0,"<All groups>")
         item,ok = QtGui.QInputDialog.getItem(window,'DynamicData','Move properties to new group tool.\n\n\
@@ -1440,9 +1442,9 @@ Select source group to pick properties from, or all groups to pick from all.\n',
                 for prop in props:
                     try:
                         obj.setGroupOfProperty(prop,newName)
-                        FreeCAD.Console.PrintMessage(f"Property {prop} move to group {newName}\n")
+                        FreeCAD.Console.PrintMessage(f'DynamicData: Property {prop} move to group {newName}\n')
                     except Exception as ex:
-                        FreeCAD.Console.PrintError(f"Cannot move {prop}, only dynamic properties are supported\n")
+                        FreeCAD.Console.PrintError(f'DynamicData: Cannot move {prop}, only dynamic properties are supported\n')
                 doc.commitTransaction()
         if obj in selection:
             FreeCADGui.Selection.removeSelection(obj)
@@ -1491,7 +1493,6 @@ class DynamicDataRenamePropertyCommandClass(object):
                 return []
             return item
         else:
-            FreeCAD.Console.PrintError(f"{obj.Label} has no dynamic properties\n")
 
     def isDynamic(self, obj, prop):
         if prop == "DynamicData":
@@ -1505,6 +1506,7 @@ class DynamicDataRenamePropertyCommandClass(object):
         except:
             isSo = False
         return isSo
+            FreeCAD.Console.PrintError(f'DynamicData: {obj.Label} has no dynamic properties\n')
 
     def getOutExpr(self, obj, prop):
         """get the expression set for this property, if any"""
@@ -1551,7 +1553,7 @@ class DynamicDataRenamePropertyCommandClass(object):
         if not newName:
             return
         if not "dd" in newName[:2] or bool(newName[2:3] < "A" or newName[2:3] > "Z"):
-            FreeCAD.Console.PrintWarning("Not all dd commands will function properly if you don't follow the dd naming convention of ddUppercase\n")
+            FreeCAD.Console.PrintWarning(f"DynamicData: Not all DynamicData commands will function properly if you don't follow the DynamicData naming convention of {propertyPrefix}Uppercase\n")
         inExprs = self.getInExprs(obj, prop)
         typeId = obj.getTypeIdOfProperty(prop)
         docu = obj.getDocumentationOfProperty(prop)
@@ -1615,7 +1617,6 @@ class DynamicDataSetTooltipCommandClass(object):
                 return []
             return item
         else:
-            FreeCAD.Console.PrintError(f"{obj.Label} has no dynamic properties\n")
 
     def isDynamic(self, obj, prop):
         if prop == "DynamicData":
@@ -1629,6 +1630,7 @@ class DynamicDataSetTooltipCommandClass(object):
         except:
             isSo = False
         return isSo
+            FreeCAD.Console.PrintError(f'DynamicData: {obj.Label} has no dynamic properties\n')
 
     def getNewTooltip(self, obj, prop):
         """get from user new tooltip for this property"""
@@ -1728,7 +1730,7 @@ class DynamicDataRemovePropertyCommandClass(object):
             try:
                 obj.removeProperty(item)
             except Exception as ex:
-                FreeCAD.Console.PrintError(f"DynamicData::Exception cannot remove {item}\n{ex}")
+                FreeCAD.Console.PrintError(f'DynamicData::Exception cannot remove {item}\n{ex}')
         obj.Document.commitTransaction()
         if obj in selection:
             FreeCADGui.Selection.removeSelection(obj)
@@ -1791,15 +1793,15 @@ class DynamicDataImportAliasesCommandClass(object):
                 if not dd:
                     dd = obj
                 else:
-                    FreeCAD.Console.PrintMessage("Can only have one dd object selected for this operation\n")
+                    FreeCAD.Console.PrintMessage('DynamicData: Can only have one DynamicData object selected for this operation\n')
                     return
         if len(sheets)==0:
             #todo: handle no selected spreadsheets.  For now, just return
-            FreeCAD.Console.PrintMessage("DynamicData: No selected spreadsheet(s)\n")
+            FreeCAD.Console.PrintMessage('DynamicData: No selected spreadsheet(s)\n')
             return
         if not dd:
             #todo: handle no dd object selected.  For now, just return
-            FreeCAD.Console.PrintMessage("DynamicData: No selected dd object\n")
+            FreeCAD.Console.PrintMessage('DynamicData: No selected dd object\n')
             return
 
         #sanity check
@@ -1845,7 +1847,7 @@ You should save your document before proceeding.\n',items,0,False,windowFlags)
                 if not line[idx:idx2][-1]=="_": #skip aliases that end in an underscore
                     aliases.append(line[idx:idx2])
                 else:
-                    FreeCAD.Console.PrintWarning('DynamicData: skipping alias \"'+line[idx:idx2]+'\" because it ends in an underscore (_).\n')
+                    FreeCAD.Console.PrintWarning(f'DynamicData: skipping alias "{line[idx:idx2]}" because it ends in an underscore (_).\n')
 
 
             for alias in aliases:
@@ -1871,17 +1873,17 @@ You should save your document before proceeding.\n',items,0,False,windowFlags)
                     propertyType='String'
                     userString=atr
                 else:
-                    FreeCAD.Console.PrintError('DynamicData: please report: unknown property type error importing alias from spreadsheet ('+str(type(atr))+')\n')
+                    FreeCAD.Console.PrintError(f'DynamicData: please report: unknown property type error importing alias from spreadsheet ({type(atr)})\n')
                     continue
 
                 name = 'dd'+sheet.Label+'_'+cap(alias)
                 if not hasattr(dd,name): #avoid adding the same property again
                     dd.addProperty('App::Property'+propertyType,name,'Imported from: '+sheet.Label, propertyType)
                     setattr(dd,name,userString)
-                    FreeCAD.Console.PrintMessage('DynamicData: adding property: '+name+' to dd object, resetting spreadsheet: '+sheet.Label+'.'+alias+' to point to '+dd.Label+'.'+name+'\n')
                     sheet.set(alias,str('='+dd.Label+'.'+name))
+                    FreeCAD.Console.PrintMessage(f'DynamicData: adding property: {name} to DynamicData object, resetting spreadsheet: {sheet.Label}.{alias} to point to {dd.Label}.{name}\n')
                 else:
-                    FreeCAD.Console.PrintWarning('DynamicData: skipping existing property: '+name+'\n')
+                    FreeCAD.Console.PrintWarning(f'DynamicData: skipping existing property: {name}\n')
                 continue
 
         FreeCAD.ActiveDocument.commitTransaction()
@@ -1955,15 +1957,15 @@ class DynamicDataImportNamedConstraintsCommandClass(object):
                 if not dd:
                     dd = obj
                 else:
-                    FreeCAD.Console.PrintMessage("Can only have one dd object selected for this operation\n")
+                    FreeCAD.Console.PrintMessage('DynamicData: Can only have one DynamicData object selected for this operation\n')
                     return
         if len(sketches)==0:
             #todo: handle no selected sketches.  For now, just return
-            FreeCAD.Console.PrintMessage("DynamicData: No selected sketch(es)\n")
+            FreeCAD.Console.PrintMessage('DynamicData: No selected sketch(es)\n')
             return
         if not dd:
             #todo: handle no dd object selected.  For now, just return
-            FreeCAD.Console.PrintMessage("DynamicData: No selected dd object\n")
+            FreeCAD.Console.PrintMessage('DynamicData: No selected DynamicData object\n')
             return
 
         #sanity check
@@ -1996,17 +1998,17 @@ You should save your document before proceeding\n',items,0,False,windowFlags)
                 if not con.Name or con.Name[-1:]=='_': #ignore constraint names ending in underscore
                     continue
                 if ' ' in con.Name:
-                    FreeCAD.Console.PrintWarning('DynamicData: skipping \"'+con.Name+'\" Spaces invalid in constraint names.\n')
+                    FreeCAD.Console.PrintWarning(f'DynamicData: skipping "{con.Name}" Spaces invalid in constraint names.\n')
                     continue
                 if not con.Driving:
-                    FreeCAD.Console.PrintWarning('DynamicData: skipping \"'+con.Name+'\" Reference constraints skipped.\n')
+                    FreeCAD.Console.PrintWarning(f'DynamicData: skipping "{con.Name}" Reference constraints skipped.\n')
                     continue
                 constraints.append({'constraintName':con.Name,'value':con.Value,'constraintType':con.Type,'sketchLabel':sketch.Label, 'sketch':sketch})
                 #try:
                 #    pass
                 #    #sketch.setExpression('Constraints.'+con.Name, dd.Label+'.dd'+sketch.Label+cap(con.Name))
                 #except:
-                #    FreeCAD.Console.PrintError('DynamicData: Exception setting expression for '+con.Name+' (skipping)\n')
+                #    FreeCAD.Console.PrintError(f'DynamicData: Exception setting expression for "{con.Name}" (skipping)\n')
                 #    constraints.pop() #remove the constraint that gave the error
         if len(constraints)==0:
             FreeCAD.Console.PrintMessage('DynamicData: No named constraints found.\n')
@@ -2022,11 +2024,11 @@ You should save your document before proceeding\n',items,0,False,windowFlags)
             if not hasattr(dd,name): #avoid adding the same property again
                 dd.addProperty('App::Property'+propertyType,name,'Imported from:'+con['sketchLabel'],'['+propertyType+'] constraint type: ['+con['constraintType']+']')
                 setattr(dd,name,value)
-                FreeCAD.Console.PrintMessage('DynamicData: adding property: '+name+' to dd object\n')
+                FreeCAD.Console.PrintMessage(f'DynamicData: adding property: {name} to DynamicData object\n')
                 sketch = con['sketch']
                 sketch.setExpression('Constraints.'+con['constraintName'], dd.Label+'.dd'+sketch.Label+cap(con['constraintName']))
             else:
-                FreeCAD.Console.PrintWarning('DynamicData: skipping existing property: '+name+'\n')
+                FreeCAD.Console.PrintWarning(f'DynamicData: skipping existing property:{name}\n')
         FreeCAD.ActiveDocument.commitTransaction()
         doc.recompute()
         return
@@ -2222,14 +2224,14 @@ Enter the name for the new property\n',text=name, flags=windowFlags)
                     toObj.addProperty('App::Property'+propertyType.replace('(ViewObject)',''), name,'Copied from: '+fromObj.Label,'['+propertyType+']')
                     toProperty = {'name':name,'type':propertyType,'value':property['value']}
                 except:
-                    FreeCAD.Console.PrintError('DynamicData: Exception trying to add property ('+property['name']+')\n')
+                    FreeCAD.Console.PrintError(f'DynamicData: Exception trying to add property ({property["name"]})\n')
                 try:
                     if propertyType=='String':
                         setattr(toObj,name,str(property['value']))
                     else:
                         setattr(toObj,name,property['value'])
                 except:
-                    FreeCAD.Console.PrintError('DynamicData: Exception trying to set property value ('+str(property['value'])+')\nCould be a property type mismatch.\n')
+                    FreeCAD.Console.PrintError(f'DynamicData: Exception trying to set property value ({property["value"]})\nCould be a property type mismatch.\n')
                 doc.commitTransaction()
                 doc.recompute()
                 self.makeParametric(fromObj, fromProperty, toObj, toProperty)
@@ -2287,12 +2289,12 @@ Enter the name for the new property\n',text=name, flags=windowFlags)
                     else:
                         setattr(toObj,toProperty['name'],fromProperty['value'])
                 except:
-                    FreeCAD.Console.PrintError(\
-'DynamicData: Exception trying to set property value ('+str(fromProperty['value'])+')\n\
-Could be a property type mismatch\n\
-\n\
-From Object: '+fromObj.Label+', From Property: '+fromProperty['name']+', type: '+fromProperty['type']+'\n\
-To Object: '+toObj.Label+', To Property: '+toProperty['name']+', type: '+toProperty['type']+'\n')
+                    FreeCAD.Console.PrintError(
+                        f'DynamicData: Exception trying to set property value ({fromProperty["value"]})\n'
+                        f'Could be a property type mismatch\n'
+                        f'\n'
+                        f'From Object: {fromObj.Label}, From Property: {fromProperty["name"]}, type: {fromProperty["type"]}\n'
+                        f'To Object: {toObj.Label}, To Property: {toProperty["name"]}, type: {toProperty["type"]}\n')
                 doc.commitTransaction()
                 doc.recompute()
                 self.makeParametric(fromObj, fromProperty, toObj, toProperty)
@@ -2352,12 +2354,12 @@ To Object: '+toObj.Label+', To Property: '+toProperty['name']+', type: '+toPrope
                     toObj.setExpression(toProperty['name']+'.y', None)
                     toObj.setExpression(toProperty['name']+'.z', None)
             except:
-                FreeCAD.Console.PrintError(\
-'DynamicData: Exception trying to parametrically link ('+str(fromProperty['value'])+')\n\
-Could be a property type mismatch\n\
-\n\
-From Object: '+fromObj.Label+', From Property: '+fromProperty['name']+', type: '+fromProperty['type']+'\n\
-To Object: '+toObj.Label+', To Property: '+toProperty['name']+', type: '+toProperty['type']+'\n')
+                FreeCAD.Console.PrintError(
+                    f'DynamicData: Exception trying to parametrically link ({fromProperty["value"]})\n'
+                    f'Could be a property type mismatch\n'
+                    f'\n'
+                    f'From Object: {fromObj.Label}, From Property: {fromProperty["name"]}, type: {fromProperty["type"]}\n'
+                    f'To Object: {toObj.Label}, To Property: {toProperty["name"]}, type: {toProperty["type"]}\n')
             return
 
         #handle placement types
@@ -2380,12 +2382,12 @@ To Object: '+toObj.Label+', To Property: '+toProperty['name']+', type: '+toPrope
                     toObj.setExpression(toProperty['name']+'.Rotation.Axis.y', None)
                     toObj.setExpression(toProperty['name']+'.Rotation.Axis.z', None)
             except:
-                FreeCAD.Console.PrintError(\
-'DynamicData: Exception trying to parametrically link ('+str(fromProperty['value'])+')\n\
-Could be a property type mismatch\n\
-\n\
-From Object: '+fromObj.Label+', From Property: '+fromProperty['name']+', type: '+fromProperty['type']+'\n\
-To Object: '+toObj.Label+', To Property: '+toProperty['name']+', type: '+toProperty['type']+'\n')
+                FreeCAD.Console.PrintError(
+                    f'DynamicData: Exception trying to parametrically link ({fromProperty["value"]})\n'
+                    f'Could be a property type mismatch\n'
+                    f'\n'
+                    f'From Object: {fromObj.Label}, From Property: {fromProperty["name"]}, type: {fromProperty["type"]}\n'
+                    f'To Object: {toObj.Label}, To Property: {toProperty["name"]}, type: {toProperty["type"]}\n')
             return
 
         #handle all other general types
@@ -2395,12 +2397,12 @@ To Object: '+toObj.Label+', To Property: '+toProperty['name']+', type: '+toPrope
             else: #break the link
                 toObj.setExpression(toProperty['name'], None)
         except:
-            FreeCAD.Console.PrintError(\
-'DynamicData: Exception trying to parametrically link ('+str(fromProperty['value'])+')\n\
-Could be a property type mismatch\n\
-\n\
-From Object: '+fromObj.Label+', From Property: '+fromProperty['name']+', type: '+fromProperty['type']+'\n\
-To Object: '+toObj.Label+', To Property: '+toProperty['name']+', type: '+toProperty['type']+'\n')
+            FreeCAD.Console.PrintError(
+                f'DynamicData: Exception trying to parametrically link ({fromProperty["value"]})\n'
+                f'Could be a property type mismatch\n'
+                f'\n'
+                f'From Object: {fromObj.Label}, From Property: {fromProperty["name"]}, type: {fromProperty["type"]}\n'
+                f'To Object: {toObj.Label}, To Property: {toProperty["name"]}, type: {toProperty["type"]}\n')
         return
 
     def getProperty(self,obj,msg='',allowMultiple=False,matchType=''):

--- a/DynamicDataCmd.py
+++ b/DynamicDataCmd.py
@@ -1772,8 +1772,8 @@ class DynamicDataImportAliasesCommandClass(object):
     def GetResources(self):
         return {'Pixmap'  : os.path.join( iconPath , 'ImportAliases.svg'),
                 'MenuText': "&Import Aliases",
-                'ToolTip' : "Import aliases from selected spreadsheet(s) into selected dd object"}
 
+                'ToolTip' : "Import aliases from selected spreadsheet(s) into selected DynamicData object"}
 
     def Activated(self):
 
@@ -1938,8 +1938,8 @@ class DynamicDataImportNamedConstraintsCommandClass(object):
     def GetResources(self):
         return {'Pixmap'  : os.path.join( iconPath , 'ImportNamedConstraints.svg'),
                 'MenuText': "&Import Named Constraints",
-                'ToolTip' : "Import named constraints from selected sketch(es) into selected dd object"}
 
+                'ToolTip' : "Import named constraints from selected sketch(es) into selected DynamicData object"}
 
     def Activated(self):
         sketches=[]

--- a/DynamicDataCmd.py
+++ b/DynamicDataCmd.py
@@ -1692,9 +1692,12 @@ class DynamicDataRemovePropertyCommandClass(_DynamicDataPropertyCommandClass):
             dlg = SelectObjects(props,"Select dynamic properties to remove")
             dlg.all.setCheckState(QtCore.Qt.Unchecked)
             ok = dlg.exec_()
-            if not ok:
+            if ok:
+                return dlg.selected
+            else:
                 return []
-        return dlg.selected if dlg else []
+        else:
+            return []
 
     def Activated(self):
         doc = FreeCAD.ActiveDocument


### PR DESCRIPTION
As discussed in #73.

I split it into smaller commits…

I have two questions as mentioned in https://github.com/mwganson/DynamicData/commit/44577ea5646980f49b4b41f15f52e225a1078b12:
1. The original code not only checks for 'dd', but also for 'Dd'. This check has been removed. Is this still needed? (And why?)
2. The original code checks for CamelCase of property names. This check remains, but is this still needed? (And why?)

I also took the liberty to make some other mostly cosmetic changes.