### PR TITLE
Update icon path in package.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ If this is True when you create a new dd object it will be added to the currentl
 When you add a new property type you are presented with a list of property types to select from. This list is sorted alphabetically beginning with "Acceleration".  But before we get to the "Acceleration" property type we have at the top of the list the most recently used property types, which are sorted in the order of most recently used.  This setting allows you to choose how many of the most recently used property types you want listed before we get to the rest of the alphabetized list.  A setting of 0 here would disable the most recently used list.  Default is 5.  Maximum is 25.  This value is stored in FreeCAD's parameters, accessible via Tools menu -> Edit Parameters.  This parameter is an Integer type in BaseApp -> Preferences -> Mod -> DynamicData -> mruLength.
 
 ### Release notes
+* 2025.11.25 (version 2.77)<br/>
+** update icon path in package.xml -- thanks @marcuspollio<br/>
 * 2025.10.29 (version 2.76)<br/>
 ** internally reorganize python module structure -- thanks @PhoneDroid<br/>
 * 2025.08.24 (version 2.75)<br/>

--- a/freecad/Dynamic_Data/DynamicDataCmd.py
+++ b/freecad/Dynamic_Data/DynamicDataCmd.py
@@ -27,7 +27,7 @@ __title__   = "DynamicData"
 __author__  = "Mark Ganson <TheMarkster>"
 __url__     = "https://github.com/mwganson/DynamicData"
 __date__    = "2025.10.29"
-__version__ = "2.76"
+__version__ = "2.77"
 version = float(__version__)
 mostRecentTypes=[]
 mostRecentTypesLength = 5 #will be updated from parameters
@@ -3056,4 +3056,3 @@ Gui.addCommand("DynamicDataSetTooltip", DynamicDataSetTooltipCommandClass())
 Gui.addCommand("DynamicDataSettings", DynamicDataSettingsCommandClass())
 Gui.addCommand("DynamicDataCopyProperty", DynamicDataCopyPropertyCommandClass())
 Gui.addCommand("DynamicDataCommands", DynamicDataCommands())
-

--- a/package.xml
+++ b/package.xml
@@ -2,20 +2,21 @@
 <package format="1">
   <name>DynamicData</name>
   <description>Container object for holding custom properties, alternative to spreadsheet</description>
-  <version>2.76</version>
+  <version>2.77</version>
   <date>2025.10.29</date>
   <maintainer email="mwganson@gmail.com">TheMarkster</maintainer>
   <license file="LICENSE">LGPL-2.1-or-later</license>
   <url type="repository" branch="master">https://github.com/mwganson/DynamicData</url>
   <url type="documentation">https://wiki.freecad.org/DynamicData_Workbench</url>
-    <content>
+  <icon>freecad/Dynamic_Data/Resources/icons/DynamicDataLogo.svg</icon>
+
+  <content>
     <workbench>
       <name>DynamicData</name>
       <classname>DynamicDataWorkbench</classname>
       <description>Container object for holding custom properties, alternative to spreadsheet</description>
-        <version>2.76</version>
+        <version>2.77</version>
       <subdirectory>./</subdirectory>
-      <icon>Resources/icons/DynamicDataLogo.svg</icon>
       <freecadmin>0.18.0</freecadmin>
     </workbench>
   </content>


### PR DESCRIPTION
Update `<icon>` path in `package.xml` so it's a top-level tag as recommended by the [Addon Metadata guide on the wiki](https://wiki.freecad.org/Package_Metadata#Required_child_tags). Icons can be defined by content item but it's easier (single relative path) to specify only one for the whole package.